### PR TITLE
fix: composer build fix for arm64

### DIFF
--- a/apps/composer/package.json
+++ b/apps/composer/package.json
@@ -42,7 +42,6 @@
     "redis": "^5.8.3",
     "swagger-ui-express": "^5.0.1",
     "tough-cookie": "^6.0.0",
-    "tsup": "^8.5.0",
     "twitter-api-v2": "^1.27.0",
     "unipile-node-sdk": "^1.9.3",
     "zod": "^3.23.8"
@@ -52,6 +51,7 @@
     "@types/nodemailer": "^7.0.3",
     "@types/qs": "^6.14.0",
     "@types/swagger-ui-express": "^4.1.8",
+    "tsup": "^8.5.0",
     "tsx": "^4.20.6"
   }
 }


### PR DESCRIPTION

---

## Summary

fix: fix: composer build fix for arm64
`    "tsup": "^8.5.0",
` moved to devDependcies